### PR TITLE
Add CINS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The API specification is located at https://www.openfigi.com/api
       Calls OpenFIGI API with the specified arguments
 
       ID_TYPE must be one of the following: ID_ISIN, ID_BB_UNIQUE, ID_SEDOL,
-      ID_COMMON, ID_WERTPAPIER, ID_CUSIP, ID_BB, ID_ITALY, ID_EXCH_SYMBOL,
+      ID_COMMON, ID_WERTPAPIER, ID_CUSIP, ID_CINS, ID_BB, ID_ITALY, ID_EXCH_SYMBOL,
       ID_FULL_EXCHANGE_SYMBOL, COMPOSITE_ID_BB_GLOBAL,
       ID_BB_GLOBAL_SHARE_CLASS_LEVEL, ID_BB_SEC_NUM_DES, ID_BB_GLOBAL, TICKER,
       ID_CUSIP_8_CHR, OCC_SYMBOL, UNIQUE_ID_FUT_OPT, OPRA_SYMBOL,

--- a/openfigi/openfigi.py
+++ b/openfigi/openfigi.py
@@ -10,6 +10,7 @@ class OpenFigi:
                 'ID_COMMON': 'Common Code',
                 'ID_WERTPAPIER': 'Wertpapierkennnummer/WKN',
                 'ID_CUSIP': 'CUSIP',
+                'ID_CINS': 'CINS - CUSIP International Numbering System',
                 'ID_BB': 'ID BB',
                 'ID_ITALY': 'Italian Identifier Number',
                 'ID_EXCH_SYMBOL': 'Local Exchange Security Symbol',


### PR DESCRIPTION
CINS is an identifier type supported by the OpenFIGI API. Without this change, the wrapper rejects ID_CINS as a bad id_type, even though it's accepted by the server. You may want to increment the version; I did not do that.